### PR TITLE
Split logger.py in two: logger.py (logging mechanisms) / flask_logger.py (flask specific)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,45 @@
-Flask Logging
-=============
+Logging
+=======
 
 This logger is designed to send JSON to Loggly in a format that matches our
 OWS1 standard. Installation is minimal:
 
 ```bash
-pip install git+https://github.com/theorchard/logging-python-flask.git@#egg=owslogger
+pip install git+https://github.com/theorchard/python-owslogger.git@#egg=owslogger
 ```
 
-Setting your python application:
+Setting your flask python application:
 
 ```python
 from flask import Flask
+from owslogger import flask_logger
 import logging
-import owslogger
 
 
 app = Flask(__name__)
-owslogger.setup(
+flask_logger.setup(
     app, 'loggly http/s url', 'environment', 'logger_name', logging.INFO,
     'service_name', '1.0.0')
+```
+
+If your application does not use flask, you can use:
+
+```python
+from owslogger import logger
+
+# Global logger
+app_logger = logger.setup(
+    'loggly http/s url', 'environment', 'logger_name', logging.INFO,
+    'service_name', '1.0.0')
+
+# Make it specific to a request by creating an adaptor and adding the
+# correlation id.
+current_app_logger = logger.OwsLoggingAdaptor(app_logger, {
+    'correlation_id': 'correlation_id'
+})
+
+# If you just want to set the logger in one time:
+current_app_logger = logger.setup(
+    'loggly http/s url', 'environment', 'logger_name', logging.INFO,
+    'service_name', '1.0.0', correlation_id='correlation_id')
 ```

--- a/owslogger/flask_logger.py
+++ b/owslogger/flask_logger.py
@@ -1,0 +1,103 @@
+"""
+Flask Logging
+=============
+
+Util to quickly and easily setup logging on any flask application by calling
+one single method: `setup`. Example::
+
+    from flask import Flask
+    from owslogger import flask_logger
+
+    app = Flask(__name__)
+    flask_logger.setup(
+        app, 'https://logglyurl', 'dev', 'logger_name', logging.INFO,
+        'service_name', '1.0.0')
+"""
+
+from flask import g
+from flask import request
+from functools import partial
+import logging
+import uuid
+
+from owslogger import logger
+
+
+def setup(
+        app, dsn, environment, logger_name, logger_level, service_name,
+        service_version):
+    """Setup logging for the flask application.
+
+    Args:
+        app (Flask): the application to add logging to.
+        dsn (str): the data source name.
+        environment (str): the application's environment.
+        logger_name (str): name of the logger.
+        logger_level (str): logging level of the logger.
+        service_name (str): the service name.
+        service_version (str): the service version.
+    """
+
+    current_logger = logger.setup(
+        dsn, environment, logger_name, logger_level, service_name,
+        service_version)
+
+    app.global_correlation_id = partial(global_correlation_id, current_logger)
+    app.global_logger = partial(global_logger, current_logger)
+
+    app.before_request(app.global_correlation_id)
+    app.before_request(app.global_logger)
+
+
+def global_correlation_id(current_logger):
+    """Global correlation id.
+
+    The correlation id is either provided by the request, and if not, it is
+    created by the service and used whenever a call is made to another system.
+    We are using flask.g, since Flask is thread safe.
+
+    Args:
+        current_logger (Logger): the app logger.
+
+    Return:
+        str: the correlation id.
+    """
+
+    if hasattr(g, 'correlation_id'):
+        return g.correlation_id
+
+    g.correlation_id = request.headers.get('Correlation-Id')
+    if not g.correlation_id:
+        g.correlation_id = str(uuid.uuid1())
+        message = (
+            'Correlation-Id ({id}) created.'.format(id=g.correlation_id))
+    else:
+        message = (
+            'Correlation-Id ({id}) received.'.format(id=g.correlation_id))
+
+    global_logger(current_logger)
+    g.log.info(message)
+
+
+def global_logger(current_logger):
+    """Global logger
+
+    The global logger is used everywhere through the application. It formats
+    the logs following our standards and it attaches additional information
+    such as the correlation id.
+
+    Code sample:
+
+        from flask import g
+
+        @app.route('/')
+        def homepage():
+            g.log.info('User has hit the homepage')
+
+    Args:
+        logger (Logger): the application logger.
+    """
+
+    global_correlation_id(current_logger)
+    context = dict(correlation_id=g.correlation_id)
+    g.log = logger.OwsLoggingAdaptor(current_logger, context)

--- a/sample.py
+++ b/sample.py
@@ -2,10 +2,10 @@ from flask import Flask
 import logging
 from flask import g
 
-from owslogger import logger
+from owslogger import flask_logger
 
 app = Flask(__name__)
-logger.setup(
+flask_logger.setup(
     app, 'https://logglyurl', 'dev', 'logger_name', logging.INFO,
     'service_name', '1.0.0')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='owslogger',
     version='0.3.0',
-    url='https://github.com/theorchard/logging/',
+    url='https://github.com/theorchard/python-owslogger/',
     author='The Orchard',
     description=(
         'Logging library.'),

--- a/tests/test_flask_logger.py
+++ b/tests/test_flask_logger.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from flask import Flask
+from flask import g
+from unittest.mock import Mock
+from unittest.mock import patch
+import logging
+import pytest
+import uuid
+
+from sample import app
+from owslogger import flask_logger
+
+
+
+def test_setting_up_flask_app():
+    """Test setting up a flask application.
+    """
+
+    app = Flask(__name__)
+    flask_logger.setup(
+        app, '', 'qa', 'logging', logging.INFO, 'service',  '1.0.0')
+
+
+def test_app_correlation_id_creation():
+    """Test creation of the correlation id.
+    """
+
+    with app.test_request_context('/hello/'):
+        app.global_correlation_id()
+        assert g.correlation_id
+
+
+def test_app_correlation_id_reuse():
+    """Test correlation id reuse.
+
+    When passed from the header, the correlation id should be reused.
+    """
+
+    correlation_id = str(uuid.uuid1())
+    with app.test_request_context(
+            '/hello/', headers={'Correlation-Id': correlation_id}):
+        app.global_correlation_id()
+        assert g.correlation_id == correlation_id
+
+
+def test_logger_creation():
+    """Test creation of the logger.
+    """
+
+    with app.test_request_context('/hello/'):
+        app.global_logger()
+        assert g.correlation_id
+        assert isinstance(g.log, logging.LoggerAdapter)
+        assert 'correlation_id' in g.log.extra
+        assert g.log.extra.get('correlation_id') == g.correlation_id

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -119,14 +119,6 @@ def test_configure_handler_without_dsn():
     assert isinstance(current_logging.handlers[0], logging.StreamHandler)
 
 
-def test_setting_up_flask_app():
-    """Test setting up a flask application.
-    """
-
-    app = Flask(__name__)
-    logger.setup(app, '', 'qa', 'logging', logging.INFO, 'service',  '1.0.0')
-
-
 def test_configure_handler_with_dsn():
     """Test configuration of the handler.
     """
@@ -135,40 +127,6 @@ def test_configure_handler_with_dsn():
     logger.configure_handler(current_logging, 'dsn', 'qa', 'logging', '1.0.0')
     assert isinstance(current_logging.handlers[0], logger.DSNHandler)
     assert current_logging.handlers[0].dsn == 'dsn'
-
-
-def test_app_correlation_id_creation():
-    """Test creation of the correlation id.
-    """
-
-    with app.test_request_context('/hello/'):
-        app.global_correlation_id()
-        assert g.correlation_id
-
-
-def test_app_correlation_id_reuse():
-    """Test correlation id reuse.
-
-    When passed from the header, the correlation id should be reused.
-    """
-
-    correlation_id = str(uuid.uuid1())
-    with app.test_request_context(
-            '/hello/', headers={'Correlation-Id': correlation_id}):
-        app.global_correlation_id()
-        assert g.correlation_id == correlation_id
-
-
-def test_logger_creation():
-    """Test creation of the logger.
-    """
-
-    with app.test_request_context('/hello/'):
-        app.global_logger()
-        assert g.correlation_id
-        assert isinstance(g.log, logging.LoggerAdapter)
-        assert 'correlation_id' in g.log.extra
-        assert g.log.extra.get('correlation_id') == g.correlation_id
 
 
 @pytest.mark.parametrize(('level', 'expected'), [


### PR DESCRIPTION
This is so we can have more than one way to set this logger and to different type of resources (flask among others). 

Please note: this code looks large but it's just moving methods from one file to another (`logger.py` has been split in two: `logger.py` - for everything related to basic logging without having a dependency on flask, and `flask_logger.py` which requires flask installed).

@rantonmattei