### PR TITLE
Fix a few issues in ows1.

### DIFF
--- a/owslogger/logger.py
+++ b/owslogger/logger.py
@@ -8,13 +8,14 @@ specific format (json), which includes fields that are specific to the Orchard,
 such as the service name, the correlation id.
 """
 
-from requests_futures.sessions import FuturesSession
 import datetime
 import logging
 import logging.handlers
 import socket
 import traceback
 import uuid
+
+from requests_futures.sessions import FuturesSession
 
 
 LEVELS = {
@@ -56,7 +57,7 @@ def setup(
         current_logger, dsn, environment, service_name, service_version)
 
     if correlation_id:
-        context = dict(correlation_id=g.correlation_id)
+        context = dict(correlation_id=correlation_id)
         return OwsLoggingAdaptor(current_logger, context)
 
     return current_logger
@@ -165,7 +166,7 @@ class DSNHandler(logging.Handler):
                     'line': record.lineno
                 }
             }
-            session.post(self.dsn, data=payload, background_callback=callback)
+            session.post(self.dsn, json=payload, background_callback=callback)
         except (KeyboardInterrupt, SystemExit):
             raise
         except:

--- a/sample.py
+++ b/sample.py
@@ -6,8 +6,8 @@ from owslogger import flask_logger
 
 app = Flask(__name__)
 flask_logger.setup(
-    app, 'https://logglyurl', 'dev', 'logger_name', logging.INFO,
-    'service_name', '1.0.0')
+    app, 'http://logs-01.loggly.com/bulk/77c54e3f-33b7-4f8b-a2a7-dbaef3414348/tag/ows1/', 'dev', 'michael_ortali', logging.INFO,
+    'grass', '1.0.0')
 
 
 @app.route('/')


### PR DESCRIPTION
- Outside of the flask_logger.py, the use of  should not be allowed
  and since we provide in the correlation_id, that's what should be used.
- post should use  instead of  (which is bytes or string), this
  led to send to loggly a meta that's a string instead of a full json.

@rantonmattei